### PR TITLE
Fixes

### DIFF
--- a/LuaRules/Gadgets/game_end.lua
+++ b/LuaRules/Gadgets/game_end.lua
@@ -1,0 +1,20 @@
+if not gadgetHandler:IsSyncedCode() then
+    return
+end
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+function gadget:GetInfo()
+    return {
+        name      = "Game Over",
+        desc      = "GAME OVER! (handles conditions thereof)",
+        author    = "SirMaverick, Google Frog, KDR_11k, CarRepairer (unified by KingRaptor)",
+        date      = "2009",
+        license   = "GPL",
+        layer     = 1,
+        enabled   = true  --  loaded by default?
+    }
+end
+
+function gadget:GameOver()
+end
+

--- a/LuaRules/Gadgets/game_killVoice.lua
+++ b/LuaRules/Gadgets/game_killVoice.lua
@@ -1,0 +1,15 @@
+local versionNumber = "v1.0"
+
+function gadget:GetInfo()
+	return {
+		name    = "1944 Unit Kill Voice",
+		desc    = versionNumber .. " Makes certain units say things when they kill something",
+		author  = "yuritch",
+		date    = "18 March 2015",
+		license = "Public domain",
+		layer   = 10000,
+		enabled = true  --  loaded by default?
+	}
+end
+
+-- gadget is disabled


### PR DESCRIPTION
1) Game now spawns units
2) You can switch teams without the game ending

Remaining issue: Typing text doesn't work, Screen:TextInput (https://github.com/gajop/chiliui/blob/master/luaui/chili/chili/controls/screen.lua#L293) is correctly invoked but self.focusedControl is nil for some reason (it's not nil in Scened BA).
A temporary workaround is to paste text with Ctrl-V, I'll investigate later.
